### PR TITLE
Add testcase to illustrate the bug in #8330

### DIFF
--- a/editions/tw5.com/tiddlers/testcases/DataWidget/FilterMissingTiddler.tid
+++ b/editions/tw5.com/tiddlers/testcases/DataWidget/FilterMissingTiddler.tid
@@ -1,0 +1,17 @@
+title: TestCases/DataWidget/FilterMissingTiddler
+type: text/vnd.tiddlywiki-multiple
+tags: [[$:/tags/wiki-test-spec]]
+description: Filter returns title of missing tiddler
+display-format: plaintext
+
+title: Narrative
+
+When the $filter attribute of the data widget returns the title of a missing tiddler, no tiddler should be added to the output array of tiddlers.
++
+title: Output
+
+<$data $filter="missing"/>
++
+title: ExpectedResult
+
+<p>[]</p>


### PR DESCRIPTION
Add a testcase to show that a data widget whose $filter attribute returns a missing tiddler will not add a tiddler to the output.